### PR TITLE
Fixed unwrap behavior when no remaining data is available on handshake

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 group = 'org.java_websocket'
-version = '1.2.1-SNAPSHOT'
+version = '1.3.1.2-SNAPSHOT'
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 

--- a/src/main/java/org/java_websocket/AbstractWrappedByteChannel.java
+++ b/src/main/java/org/java_websocket/AbstractWrappedByteChannel.java
@@ -59,7 +59,7 @@ public class AbstractWrappedByteChannel implements WrappedByteChannel {
 	}
 
 	@Override
-	public int readMore( ByteBuffer dst ) throws SSLException {
+	public int readMore( ByteBuffer dst ) throws IOException {
 		return channel instanceof WrappedByteChannel ? ( (WrappedByteChannel) channel ).readMore( dst ) : 0;
 	}
 

--- a/src/main/java/org/java_websocket/WrappedByteChannel.java
+++ b/src/main/java/org/java_websocket/WrappedByteChannel.java
@@ -21,6 +21,6 @@ public interface WrappedByteChannel extends ByteChannel {
 	 * This function does not read data from the underlying channel at all. It is just a way to fetch data which has already be received or decoded but was but was not yet returned to the user.
 	 * This could be the case when the decoded data did not fit into the buffer the user passed to {@link #read(ByteBuffer)}.
 	 **/
-	public int readMore( ByteBuffer dst ) throws SSLException;
+	public int readMore( ByteBuffer dst ) throws IOException;
 	public boolean isBlocking();
 }


### PR DESCRIPTION
On 5.0 handshake needs several reads to get all data