### PR TITLE
Gc on connection error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 group = 'org.java_websocket'
-version = '1.2.1-SNAPSHOT'
+version = '1.2.3-SNAPSHOT'
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 

--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -244,8 +244,8 @@ public abstract class WebSocketClient extends WebSocketAdapter implements Runnab
 					conn.eot();
 				}
 
-                                // Check connection status again as WebSocketImpl#flushAndClose may break
-                                // previous blocking read but, then, get caught here
+				// Check connection status again as WebSocketImpl#flushAndClose may break
+				// previous blocking read but, then, get caught here
 				if( !conn.isClosed() && wrappedchannel instanceof WrappedByteChannel ) {
 					WrappedByteChannel w = (WrappedByteChannel) wrappedchannel;
 					if( w.isNeedRead() ) {

--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -245,7 +245,7 @@ public abstract class WebSocketClient extends WebSocketAdapter implements Runnab
 				}
 
                                 // Check connection status again as WebSocketImpl#flushAndClose may break
-				// previous blocking read but, then, get caught here
+                                // previous blocking read but, then, get caught here
 				if( !conn.isClosed() && wrappedchannel instanceof WrappedByteChannel ) {
 					WrappedByteChannel w = (WrappedByteChannel) wrappedchannel;
 					if( w.isNeedRead() ) {

--- a/src/main/java/org/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/java_websocket/client/WebSocketClient.java
@@ -244,7 +244,9 @@ public abstract class WebSocketClient extends WebSocketAdapter implements Runnab
 					conn.eot();
 				}
 
-				if( wrappedchannel instanceof WrappedByteChannel ) {
+                                // Check connection status again as WebSocketImpl#flushAndClose may break
+				// previous blocking read but, then, get caught here
+				if( !conn.isClosed() && wrappedchannel instanceof WrappedByteChannel ) {
 					WrappedByteChannel w = (WrappedByteChannel) wrappedchannel;
 					if( w.isNeedRead() ) {
 						while ( SocketChannelIOHelper.readMore( buff, conn, w ) ) {


### PR DESCRIPTION
On error reception, connection was properly closed calling WebSocketImpl#flushAndClose but, although this method was breaking blocking read, we got caught in following readMore because connection state was not re-checked.