### PR TITLE
Reversed socket channel closure order

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 group = 'org.java_websocket'
-version = '1.3.1.2-SNAPSHOT'
+version = '1.3.1.4-SNAPSHOT'
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
@@ -29,16 +29,15 @@ dependencies {
 
 
 //deploy to maven repository
-//uploadArchives {
-//    repositories.mavenDeployer {
-//        configuration = configurations.deployerJars
-//        repository(url: repositoryUrl) {
-//			authentication(userName: repositoryUsername, password: repositoryPassword)
-//		}
-//    }
-//}
+uploadArchives {
+    repositories.mavenDeployer {
+        configuration = configurations.deployerJars
+        repository(url: voalteMavenRepoUrl) {
+            authentication(userName: voalteMavenUsername, password: voalteMavenPassword)
+        }
+    }
+}
 
 task wrapper(type: Wrapper) {
     gradleVersion = '1.4'
 }
-

--- a/src/main/java/org/java_websocket/SSLSocketChannel2.java
+++ b/src/main/java/org/java_websocket/SSLSocketChannel2.java
@@ -271,8 +271,8 @@ public class SSLSocketChannel2 implements ByteChannel, WrappedByteChannel {
 	}
 
 	public void close() throws IOException {
-		sslEngine.closeOutbound();
 		sslEngine.getSession().invalidate();
+		sslEngine.closeOutbound();
 		if( socketChannel.isOpen() )
 			socketChannel.write( wrap( emptybuffer ) );// FIXME what if not all bytes can be written
 		socketChannel.close();


### PR DESCRIPTION
Calling SSLEngine.closeOutbound was also shutting down and resetting current session.